### PR TITLE
Fixes application of javac options

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,14 +12,7 @@ scalaVersion in ThisBuild := "2.12.8"
 lagomServiceEnableSsl in ThisBuild := true
 val `hello-impl-HTTPS-port` = 11000
 
-
-// ALL SETTINGS HERE ARE TEMPORARY WORKAROUNDS FOR KNOWN ISSUES OR WIP
-def workaroundSettings: Seq[sbt.Setting[_]] = Seq(
-  // Lagom still can't register a service under the gRPC name so we hard-code t
-  // he port and the use the value to add the entry on the Service Registry
-  lagomServiceHttpsPort := `hello-impl-HTTPS-port`,
-  resolvers += Resolver.bintrayRepo("akka", "maven"), // for snapshot akka-grpc
-)
+resolvers in ThisBuild += Resolver.bintrayRepo("akka", "maven") // for snapshot akka-grpc
 
 lazy val `lagom-java-grpc-example` = (project in file("."))
   .aggregate(`hello-api`, `hello-impl`, `hello-proxy-api`, `hello-proxy-impl`)
@@ -45,9 +38,11 @@ lazy val `hello-impl` = (project in file("hello-impl"))
       AkkaGrpc.Client // the client is only used in tests. See https://github.com/akka/akka-grpc/issues/410
     ),
   akkaGrpcExtraGenerators in Compile += PlayJavaServerCodeGenerator,
-).settings(
-  workaroundSettings: _*
-).settings(
+
+  // WORKAROUND: Lagom still can't register a service under the gRPC name so we hard-code
+  // the port and the use the value to add the entry on the Service Registry
+  lagomServiceHttpsPort := `hello-impl-HTTPS-port`,
+
   libraryDependencies ++= Seq(
     lagomJavadslTestKit,
     lagomLogback

--- a/build.sbt
+++ b/build.sbt
@@ -89,5 +89,5 @@ lagomUnmanagedServices in ThisBuild := Map("helloworld.GreeterService" -> s"http
 
 
 def common = Seq(
-  javacOptions in (Compile,compile) ++= Seq("-Xlint:unchecked", "-Xlint:deprecation", "-parameters", "-Werror")
+  javacOptions in Compile ++= Seq("-Xlint:unchecked", "-Xlint:deprecation", "-parameters", "-Werror")
 )

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,8 @@ val `hello-impl-HTTPS-port` = 11000
 def workaroundSettings: Seq[sbt.Setting[_]] = Seq(
   // Lagom still can't register a service under the gRPC name so we hard-code t
   // he port and the use the value to add the entry on the Service Registry
-  lagomServiceHttpsPort := `hello-impl-HTTPS-port`
+  lagomServiceHttpsPort := `hello-impl-HTTPS-port`,
+  resolvers += Resolver.bintrayRepo("akka", "maven"), // for snapshot akka-grpc
 )
 
 lazy val `lagom-java-grpc-example` = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val `lagom-java-grpc-example` = (project in file("."))
   .aggregate(`hello-api`, `hello-impl`, `hello-proxy-api`, `hello-proxy-impl`)
 
 lazy val `hello-api` = (project in file("hello-api"))
+  .settings(common)
   .settings(
     libraryDependencies ++= Seq(
       lagomJavadslApi
@@ -34,6 +35,7 @@ lazy val `hello-impl` = (project in file("hello-impl"))
   .enablePlugins(LagomJava)
   .enablePlugins(AkkaGrpcPlugin) // enables source generation for gRPC
   .enablePlugins(PlayAkkaHttp2Support) // enables serving HTTP/2 and gRPC
+  .settings(common)
   .settings(
   akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java),
   akkaGrpcGeneratedSources :=
@@ -53,6 +55,7 @@ lazy val `hello-impl` = (project in file("hello-impl"))
   .dependsOn(`hello-api`)
 
 lazy val `hello-proxy-api` = (project in file("hello-proxy-api"))
+  .settings(common)
   .settings(
     libraryDependencies ++= Seq(
       lagomJavadslApi
@@ -62,6 +65,7 @@ lazy val `hello-proxy-api` = (project in file("hello-proxy-api"))
 lazy val `hello-proxy-impl` = (project in file("hello-proxy-impl"))
   .enablePlugins(LagomJava)
   .enablePlugins(AkkaGrpcPlugin) // enables source generation for gRPC
+  .settings(common)
   .settings(
   akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java),
   akkaGrpcExtraGenerators += PlayJavaClientCodeGenerator,
@@ -84,4 +88,6 @@ lagomKafkaEnabled in ThisBuild := false
 lagomUnmanagedServices in ThisBuild := Map("helloworld.GreeterService" -> s"https://localhost:${`hello-impl-HTTPS-port`}")
 
 
-ThisBuild / javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation", "-Werror")
+def common = Seq(
+  javacOptions in (Compile,compile) ++= Seq("-Xlint:unchecked", "-Xlint:deprecation", "-parameters", "-Werror")
+)

--- a/hello-impl/src/main/java/com/example/hello/impl/HelloGrpcServiceImpl.java
+++ b/hello-impl/src/main/java/com/example/hello/impl/HelloGrpcServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.hello.impl;
 
+import akka.actor.ActorSystem;
 import akka.stream.Materializer;
 import example.myapp.helloworld.grpc.AbstractGreeterServiceRouter;
 import example.myapp.helloworld.grpc.HelloReply;
@@ -14,8 +15,8 @@ import java.util.concurrent.CompletionStage;
 public class HelloGrpcServiceImpl extends AbstractGreeterServiceRouter {
 
     @Inject
-    public HelloGrpcServiceImpl(Materializer mat) {
-        super(mat);
+    public HelloGrpcServiceImpl(ActorSystem sys, Materializer mat) {
+        super(mat, sys);
     }
 
     @Override

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,8 @@
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-RC2")
 
 // Akka GRPC
-addSbtPlugin("com.lightbend.akka.grpc" %% "sbt-akka-grpc" % "0.4.2")
+addSbtPlugin("com.lightbend.akka.grpc" %% "sbt-akka-grpc" % "0.5.0+14-c97a24a0")
+resolvers += Resolver.bintrayRepo("akka", "maven") // for the snapshot ^
 
 
 // Needed for importing the project into Eclipse

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,7 @@ addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-RC2")
 
 // Akka GRPC
 addSbtPlugin("com.lightbend.akka.grpc" %% "sbt-akka-grpc" % "0.5.0+14-c97a24a0")
-resolvers += Resolver.bintrayRepo("akka", "maven") // for the snapshot ^
-
+resolvers += Resolver.bintrayRepo("akka", "sbt-plugin-releases") // for the snapshot ^
 
 // Needed for importing the project into Eclipse
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,10 @@ addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-RC2")
 
 // Akka GRPC
 addSbtPlugin("com.lightbend.akka.grpc" %% "sbt-akka-grpc" % "0.5.0+14-c97a24a0")
-resolvers += Resolver.bintrayRepo("akka", "sbt-plugin-releases") // for the snapshot ^
+resolvers ++= Seq(          // for the snapshot ^
+  Resolver.bintrayIvyRepo("akka", "sbt-plugin-releases"),
+  Resolver.bintrayRepo("akka", "maven"),
+)
 
 // Needed for importing the project into Eclipse
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")


### PR DESCRIPTION
This PR fixes the syntax to enable `javacOptions` in each of the `sbt` modules.

This fix revealed a deprecation warning in akka-grpc generated code. The consequence of this warning with the `-Werror` flag is the build of this PR will break. Unfortunately the newet `0.5.0` release of `akka-grpc` introduces other compilation errors on the generated code so at the moment we can't have a 100% error-free lagom-grpc sample.